### PR TITLE
Removed dagger support

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -5,7 +5,7 @@ object Versions {
     const val targetSdk = 30
 
     const val kotlin = "1.4.32"
-    const val dagger = "2.24"
+    const val dagger = "2.35.1"
     const val androidx_appcompat = "1.2.0"
     const val androidx_core_ktx = "1.3.2"
     const val navigation = "2.3.5"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,9 +27,7 @@ object Dependencies {
 
     object Dagger {
         private const val base_url = "com.google.dagger"
-        const val core = "$base_url:dagger-android-support:${Versions.dagger}"
         const val dagger_android = "$base_url:dagger-android:${Versions.dagger}"
-        const val dagger_android_support = "$base_url:dagger-android-support:${Versions.dagger}"
         const val dagger_android_processor = "$base_url:dagger-android-processor:${Versions.dagger}"
         const val dagger_android_compiler = "$base_url:dagger-compiler:${Versions.dagger}"
     }

--- a/link-payments/build.gradle.kts
+++ b/link-payments/build.gradle.kts
@@ -33,9 +33,7 @@ dependencies {
 
     implementation(Dependencies.kotlin_stdlib)
 
-    implementation(Dependencies.Dagger.core)
     implementation(Dependencies.Dagger.dagger_android)
-    implementation(Dependencies.Dagger.dagger_android_support)
     kapt(Dependencies.Dagger.dagger_android_processor)
     kapt(Dependencies.Dagger.dagger_android_compiler)
 

--- a/link-ui/build.gradle.kts
+++ b/link-ui/build.gradle.kts
@@ -50,9 +50,7 @@ dependencies {
     androidTestImplementation(Dependencies.Androidx.test_runner)
     androidTestImplementation(Dependencies.Androidx.test_espresso)
 
-    implementation(Dependencies.Dagger.core)
     implementation(Dependencies.Dagger.dagger_android)
-    implementation(Dependencies.Dagger.dagger_android_support)
     kapt(Dependencies.Dagger.dagger_android_processor)
     kapt(Dependencies.Dagger.dagger_android_compiler)
 

--- a/link/build.gradle.kts
+++ b/link/build.gradle.kts
@@ -38,9 +38,7 @@ dependencies {
 
     implementation(Dependencies.kotlin_stdlib)
 
-    implementation(Dependencies.Dagger.core)
     implementation(Dependencies.Dagger.dagger_android)
-    implementation(Dependencies.Dagger.dagger_android_support)
     kapt(Dependencies.Dagger.dagger_android_processor)
     kapt(Dependencies.Dagger.dagger_android_compiler)
 

--- a/sample-link-payments/build.gradle.kts
+++ b/sample-link-payments/build.gradle.kts
@@ -42,9 +42,7 @@ dependencies {
     androidTestImplementation(Dependencies.Androidx.test_runner)
     androidTestImplementation(Dependencies.Androidx.test_espresso)
 
-    implementation(Dependencies.Dagger.core)
     implementation(Dependencies.Dagger.dagger_android)
-    implementation(Dependencies.Dagger.dagger_android_support)
     kapt(Dependencies.Dagger.dagger_android_processor)
     kapt(Dependencies.Dagger.dagger_android_compiler)
 

--- a/sample-link-ui/build.gradle.kts
+++ b/sample-link-ui/build.gradle.kts
@@ -39,9 +39,7 @@ dependencies {
     implementation(Dependencies.Androidx.core_ktx)
     implementation(Dependencies.Androidx.constraint_layout)
 
-    implementation(Dependencies.Dagger.core)
     implementation(Dependencies.Dagger.dagger_android)
-    implementation(Dependencies.Dagger.dagger_android_support)
     kapt(Dependencies.Dagger.dagger_android_processor)
     kapt(Dependencies.Dagger.dagger_android_compiler)
 

--- a/sample-link/build.gradle.kts
+++ b/sample-link/build.gradle.kts
@@ -38,9 +38,7 @@ dependencies {
     implementation(Dependencies.Androidx.core_ktx)
     implementation(Dependencies.Androidx.constraint_layout)
 
-    implementation(Dependencies.Dagger.core)
     implementation(Dependencies.Dagger.dagger_android)
-    implementation(Dependencies.Dagger.dagger_android_support)
     kapt(Dependencies.Dagger.dagger_android_processor)
     kapt(Dependencies.Dagger.dagger_android_compiler)
 


### PR DESCRIPTION
I removed the dagger-android-support library because this library only should be added if in your project use the android support library instead of androidx.