### PR TITLE
JASP-951 Update sample-app & sample-dev

### DIFF
--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -36,6 +36,7 @@ android {
     }
     buildFeatures {
         compose true
+        buildConfig true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "$kotlin_compiler_extension_version"

--- a/sample-app/src/main/java/com/tink/link/app/SampleActivity.kt
+++ b/sample-app/src/main/java/com/tink/link/app/SampleActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.tink.link.app.theme.WebTheme
 import com.tink.link.core.base.Tink
 import com.tink.link.core.data.request.configuration.BaseDomain
+import com.tink.link.app.BuildConfig
 import com.tink.link.core.data.request.configuration.Configuration
 
 class SampleActivity : ComponentActivity() {
@@ -58,7 +59,10 @@ class SampleActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        Log.d(TAG, "onNewIntent() intent.data = ${intent.data}")
+        // WARNING: Never log intent.data in production — it may contain OAuth authorization codes.
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "onNewIntent() intent received")
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/sample-app/src/main/java/com/tink/link/app/navToFlows/FlowCases.kt
+++ b/sample-app/src/main/java/com/tink/link/app/navToFlows/FlowCases.kt
@@ -2,6 +2,7 @@ package com.tink.link.app.navToFlows
 
 import android.app.Activity
 import android.util.Log
+import com.tink.link.app.BuildConfig
 import com.tink.link.app.NecessaryIds
 import com.tink.link.app.TAG
 import com.tink.link.core.base.Tink
@@ -419,8 +420,11 @@ fun showConnectAccountsForOneTimeAccess(
         oneTimeAccess,
         launchMode,
         { success: TinkTransactionsSuccess ->
-            Log.d(TAG, "credentials_id = ${success.credentialsId}")
-            Log.d(TAG, "code = ${success.code}")
+            // WARNING: Do not log authorization codes or credentials IDs in production.
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "credentials_id = ${success.credentialsId}")
+                Log.d(TAG, "code = ${success.code}")
+            }
         },
         { error: TinkError ->
             Log.d(TAG, "error message = ${error.errorDescription}")
@@ -449,8 +453,11 @@ fun showConnectAccountsForBusinessOneTimeAccess(
         oneTimeAccess,
         launchMode,
         { success: TinkBusinessTransactionsSuccess ->
-            Log.d(TAG, "credentials_id = ${success.credentialsId}")
-            Log.d(TAG, "code = ${success.code}")
+            // WARNING: Do not log authorization codes or credentials IDs in production.
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "credentials_id = ${success.credentialsId}")
+                Log.d(TAG, "code = ${success.code}")
+            }
         },
         { error: TinkError ->
             Log.d(TAG, "error message = ${error.errorDescription}")
@@ -483,7 +490,10 @@ fun showConnectAccountsForContinuousAccess(
         continuousAccessConnect,
         launchMode,
         { success: TinkTransactionsSuccess ->
-            Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            // WARNING: Do not log credentials IDs in production.
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            }
         },
         { error: TinkError ->
             Log.d(TAG, "error message = ${error.errorDescription}")
@@ -516,7 +526,10 @@ fun showConnectAccountsForBusinessContinuousAccess(
         continuousAccessConnect,
         launchMode,
         { success: TinkBusinessTransactionsSuccess ->
-            Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            // WARNING: Do not log credentials IDs in production.
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            }
         },
         { error: TinkError ->
             Log.d(TAG, "error message = ${error.errorDescription}")
@@ -550,7 +563,10 @@ fun showUpdateConsent(
         continuousAccessUpdate,
         launchMode,
         { success: TinkTransactionsSuccess ->
-            Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            // WARNING: Do not log credentials IDs in production.
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            }
         },
         { error: TinkError ->
             Log.d(TAG, "error message = ${error.errorDescription}")
@@ -584,7 +600,10 @@ fun showBusinessUpdateConsent(
         continuousAccessUpdate,
         launchMode,
         { success: TinkBusinessTransactionsSuccess ->
-            Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            // WARNING: Do not log credentials IDs in production.
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            }
         },
         { error: TinkError ->
             Log.d(TAG, "error message = ${error.errorDescription}")
@@ -618,7 +637,10 @@ fun showExtendConsent(
         continuousAccessExtend,
         launchMode,
         { success: TinkTransactionsSuccess ->
-            Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            // WARNING: Do not log credentials IDs in production.
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            }
         },
         { error: TinkError ->
             Log.d(TAG, "error message = ${error.errorDescription}")
@@ -652,7 +674,10 @@ fun showBusinessExtendConsent(
         continuousAccessExtend,
         launchMode,
         { success: TinkBusinessTransactionsSuccess ->
-            Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            // WARNING: Do not log credentials IDs in production.
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            }
         },
         { error: TinkError ->
             Log.d(TAG, "error message = ${error.errorDescription}")
@@ -689,8 +714,11 @@ fun showAccountAggregationAuthorizeForOneTimeAccess(
         authorizeForOneTimeAccess,
         launchMode,
         { success: TinkAccountAggregationSuccess ->
-            Log.d(TAG, "code = ${success.code}")
-            Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            // WARNING: Do not log authorization codes or credentials IDs in production.
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "code = ${success.code}")
+                Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            }
         },
         { error: TinkError ->
             Log.d(TAG, "error message = ${error.errorDescription}")
@@ -722,7 +750,10 @@ fun showAccountAggregationAddCredentials(
         addCredentials,
         launchMode,
         { success: TinkAccountAggregationSuccess ->
-            Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            // WARNING: Do not log credentials IDs in production.
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            }
         },
         { error: TinkError ->
             Log.d(TAG, "error message = ${error.errorDescription}")
@@ -756,7 +787,10 @@ fun showAccountAggregationRefreshCredentials(
         refreshCredentials,
         launchMode,
         { success: TinkAccountAggregationSuccess ->
-            Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            // WARNING: Do not log credentials IDs in production.
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            }
         },
         { error: TinkError ->
             Log.d(TAG, "error message = ${error.errorDescription}")
@@ -789,7 +823,10 @@ fun showAccountAggregationAuthenticateCredentials(
         authenticateCredentials,
         launchMode,
         { success: TinkAccountAggregationSuccess ->
-            Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            // WARNING: Do not log credentials IDs in production.
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            }
         },
         { error: TinkError ->
             Log.d(TAG, "error message = ${error.errorDescription}")
@@ -822,7 +859,10 @@ fun showAccountAggregationExtendConsent(
         extendConsent,
         launchMode,
         { success: TinkAccountAggregationSuccess ->
-            Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            // WARNING: Do not log credentials IDs in production.
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "credentials_id = ${success.credentialsId}")
+            }
         },
         { error: TinkError ->
             Log.d(TAG, "error message = ${error.errorDescription}")

--- a/sample-dev/build.gradle
+++ b/sample-dev/build.gradle
@@ -29,6 +29,7 @@ android {
     }
     buildFeatures {
         compose true
+        buildConfig true
     }
     kotlinOptions {
         jvmTarget = '1.8'

--- a/sample-dev/src/main/java/com/tink/link/sample/fullscreen/FullScreenActivity.kt
+++ b/sample-dev/src/main/java/com/tink/link/sample/fullscreen/FullScreenActivity.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.tink.link.core.base.Tink
 import com.tink.link.core.data.request.configuration.BaseDomain
 import com.tink.link.core.data.request.configuration.Configuration
+import com.tink.link.sample.BuildConfig
 import com.tink.link.core.data.request.transactions.ConnectAccountsForOneTimeAccess
 import com.tink.link.core.data.response.error.TinkError
 import com.tink.link.core.data.response.success.transactions.TinkTransactionsSuccess
@@ -64,8 +65,11 @@ class FullScreenActivity : AppCompatActivity() {
             oneTimeAccess,
             fullScreen,
             { success: TinkTransactionsSuccess ->
-                Log.d(TAG, "credentials_id = ${success.credentialsId}")
-                Log.d(TAG, "code = ${success.code}")
+                // WARNING: Do not log authorization codes or credentials IDs in production.
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "credentials_id = ${success.credentialsId}")
+                    Log.d(TAG, "code = ${success.code}")
+                }
             },
             { error: TinkError ->
                 Log.d(TAG, "error message = ${error.errorDescription}")

--- a/sample-dev/src/main/java/com/tink/link/sample/fullscreen/FullScreenComposeActivity.kt
+++ b/sample-dev/src/main/java/com/tink/link/sample/fullscreen/FullScreenComposeActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.Color
 import com.tink.link.core.base.Tink
 import com.tink.link.core.data.request.configuration.BaseDomain
 import com.tink.link.core.data.request.configuration.Configuration
+import com.tink.link.sample.BuildConfig
 import com.tink.link.core.data.request.transactions.ConnectAccountsForOneTimeAccess
 import com.tink.link.core.data.response.error.TinkError
 import com.tink.link.core.data.response.success.transactions.TinkTransactionsSuccess
@@ -56,8 +57,11 @@ class FullScreenComposeActivity : ComponentActivity() {
             oneTimeAccess,
             fullScreen,
             { success: TinkTransactionsSuccess ->
-                Log.d(TAG, "credentials_id = ${success.credentialsId}")
-                Log.d(TAG, "code = ${success.code}")
+                // WARNING: Do not log authorization codes or credentials IDs in production.
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "credentials_id = ${success.credentialsId}")
+                    Log.d(TAG, "code = ${success.code}")
+                }
             },
             { error: TinkError ->
                 Log.d(TAG, "error message = ${error.errorDescription}")

--- a/sample-dev/src/main/java/com/tink/link/sample/modal/ModalActivity.kt
+++ b/sample-dev/src/main/java/com/tink/link/sample/modal/ModalActivity.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.tink.link.core.base.Tink
 import com.tink.link.core.data.request.configuration.BaseDomain
 import com.tink.link.core.data.request.configuration.Configuration
+import com.tink.link.sample.BuildConfig
 import com.tink.link.core.data.request.transactions.ConnectAccountsForOneTimeAccess
 import com.tink.link.core.data.response.error.TinkError
 import com.tink.link.core.data.response.success.transactions.TinkTransactionsSuccess
@@ -64,8 +65,11 @@ class ModalActivity : AppCompatActivity() {
             oneTimeAccess,
             modal,
             { success: TinkTransactionsSuccess ->
-                Log.d(TAG, "credentials_id = ${success.credentialsId}")
-                Log.d(TAG, "code = ${success.code}")
+                // WARNING: Do not log authorization codes or credentials IDs in production.
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "credentials_id = ${success.credentialsId}")
+                    Log.d(TAG, "code = ${success.code}")
+                }
             },
             { error: TinkError ->
                 Log.d(TAG, "error message = ${error.errorDescription}")

--- a/sample-dev/src/main/java/com/tink/link/sample/modal/ModalComposeActivity.kt
+++ b/sample-dev/src/main/java/com/tink/link/sample/modal/ModalComposeActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.graphics.Color
 import com.tink.link.core.base.Tink
 import com.tink.link.core.data.request.configuration.BaseDomain
 import com.tink.link.core.data.request.configuration.Configuration
+import com.tink.link.sample.BuildConfig
 import com.tink.link.core.data.request.transactions.ConnectAccountsForOneTimeAccess
 import com.tink.link.core.data.response.error.TinkError
 import com.tink.link.core.data.response.success.transactions.TinkTransactionsSuccess
@@ -65,8 +66,11 @@ class ModalComposeActivity : ComponentActivity() {
             oneTimeAccess,
             modal,
             { success: TinkTransactionsSuccess ->
-                Log.d(TAG, "credentials_id = ${success.credentialsId}")
-                Log.d(TAG, "code = ${success.code}")
+                // WARNING: Do not log authorization codes or credentials IDs in production.
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "credentials_id = ${success.credentialsId}")
+                    Log.d(TAG, "code = ${success.code}")
+                }
             },
             { error: TinkError ->
                 Log.d(TAG, "error message = ${error.errorDescription}")


### PR DESCRIPTION
Addresses a security finding where OAuth authorization codes (success.code), credentials IDs (success.credentialsId), and raw deep-link URIs were logged unredacted to logcat in all sample callbacks.